### PR TITLE
[Jitera] Implement Topic Selection Functionality

### DIFF
--- a/public/locales/en/all.json
+++ b/public/locales/en/all.json
@@ -23,5 +23,15 @@
   "500": {
     "title": "System Error",
     "description": "Description about system error"
+  },
+  "FAQItem": {
+    "indicatorAlt": "Indicator",
+    "arrowAlt": "Arrow"
+  },
+  "FAQList": {
+    "timing_of_starting": "Timing of starting",
+    "how_to_take": "How to take",
+    "title": "Frequently Asked Questions",
+    "description": "Here you can find answers to the most common questions."
   }
 }

--- a/src/components/molecules/FAQItem/index.module.css
+++ b/src/components/molecules/FAQItem/index.module.css
@@ -1,0 +1,40 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 12px;
+  width: 311px;
+}
+
+.indicator {
+  width: 20px;
+  height: 20px;
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.number {
+  font-weight: 800;
+  font-size: 18px;
+  line-height: 18px;
+  color: #1D1617;
+}
+
+.question {
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 15px;
+  color: #1D1617;
+}
+
+.arrow {
+  padding: 5px;
+  background-color: rgba(255, 123, 55, 0.1);
+  border-radius: 24px;
+}

--- a/src/components/molecules/FAQItem/index.tsx
+++ b/src/components/molecules/FAQItem/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styles from './index.module.css';
+import { useTranslation } from 'next-i18next';
+
+export interface FAQItemProps {
+  number: number;
+  question: string;
+}
+
+const FAQItem: React.FC<FAQItemProps> = ({ number, question }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.indicator}>
+        <img src="https://studio-next.jitera.app/no.png" alt={t('FAQItem.indicatorAlt')} />
+      </div>
+      <div className={styles.content}>
+        <span className={styles.number}>{number}.</span>
+        <span className={styles.question}>{t(question)}</span>
+      </div>
+      <div className={styles.arrow}>
+        <img src="https://studio-next.jitera.app/no.png" alt={t('FAQItem.arrowAlt')} />
+      </div>
+    </div>
+  );
+};
+
+export default FAQItem;

--- a/src/components/pages/FAQList/index.module.css
+++ b/src/components/pages/FAQList/index.module.css
@@ -1,0 +1,5 @@
+.page_container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/components/pages/FAQList/index.tsx
+++ b/src/components/pages/FAQList/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useTranslation } from 'next-i18next';
+import FAQItem from '@components/molecules/FAQItem';
+import styles from './index.module.css';
+
+const FAQList: React.FC = () => {
+  const { t } = useTranslation();
+  const faqData = [
+    // This should be fetched from an API or imported from a constants file
+    { number: 1, question: 'FAQList.timing_of_starting' },
+    { number: 2, question: 'FAQList.how_to_take' },
+    // ... add more FAQ items here
+  ];
+
+  return (
+    <div className={styles.page_container}>
+      {faqData.map((faq, index) => (
+        <FAQItem key={index} number={faq.number} question={t(faq.question)} />
+      ))}
+    </div>
+  );
+};
+
+export default FAQList;

--- a/src/pages/FAQList.tsx
+++ b/src/pages/FAQList.tsx
@@ -1,0 +1,18 @@
+import { GetStaticPropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import FAQListPage from '@components/pages/FAQList'
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  const { locale = 'en' } = context
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['all'])),
+      seo: {
+        title: 'FAQ List',
+        description: 'Frequently Asked Questions',
+      },
+    },
+  }
+}
+
+export default FAQListPage


### PR DESCRIPTION
This pull request is created by **JITERA**
# Description

#### [UI] Figma screens
**55:7527**
![55:7527](https://jitera-preprod-bucket.s3.ap-northeast-1.amazonaws.com/faisl7q5aq9b9jt9cztnxs3lymy2?response-content-disposition=inline%3B%20filename%3D%22fc01e05c-78e9-4a4c-99e4-5cd72a7af996%22%3B%20filename%2A%3DUTF-8%27%27fc01e05c-78e9-4a4c-99e4-5cd72a7af996&response-content-type=image%2Fpng&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4E6BLWT5TLFBWMMV%2F20240515%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20240515T115518Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=4bdd9efa9946a2d4f5e678fd4370376d5222872f98ababe5333360735258c72f)
**FAQ List**
A list of frequently asked questions with numerical ordering and arrow indicators, styled with padding, background color, and rounded borders.
* Evaluation: 65
* Run count: 2
```html
<div style="display: flex; flex-direction: column; gap: 8px;">  <div style="display: flex; align-items: center; justify-content: space-between; background-color: #fff; border-radius: 8px; padding: 12px; width: 311px;">    <div style="display: flex; align-items: center; gap: 8px;">      <div style="width: 20px; height: 20px;">        <img style="width: 100%; height: 100%;" src="https://studio-next.jitera.app/no.png" alt="Indicator">      </div>      <div style="display: flex; align-items: center; gap: 4px;">        <span style="font-weight: 800; font-size: 18px; line-height: 18px; color: #1D1617;">1.</span>        <span style="font-weight: 600; font-size: 15px; line-height: 15px; color: #1D1617;">服用開始のタイミング</span>      </div>    </div>    <div style="padding: 5px; background-color: rgba(255, 123, 55, 0.1); border-radius: 24px;">      <img style="width: 24px; height: 24px;" src="https://studio-next.jitera.app/no.png" alt="Arrow">    </div>  </div>  <!-- Repeat the above block for each item, changing the number and text accordingly. -->  <!-- ... --></div>
```
------